### PR TITLE
Fixes for stale JBoss beans.

### DIFF
--- a/src/main/java/org/collectd/FastJMX.java
+++ b/src/main/java/org/collectd/FastJMX.java
@@ -22,7 +22,6 @@ import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;

--- a/src/main/java/org/collectd/SelfTuningCollectionExecutor.java
+++ b/src/main/java/org/collectd/SelfTuningCollectionExecutor.java
@@ -21,6 +21,7 @@ import org.collectd.api.Collectd;
 import org.collectd.api.PluginData;
 import org.collectd.api.ValueList;
 
+import javax.management.InstanceNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -226,8 +227,14 @@ public class SelfTuningCollectionExecutor {
 		for (int i = 0; i < results.size(); i++) {
 			Future<AttributePermutation> result = results.get(i);
 			try {
-				dispatchable.addAll(result.get().getValues());
-				success++;
+				AttributePermutation attribute = result.get();
+				if (attribute.getConsecutiveNotFounds() > 0) {
+					failed++;
+					logger.warning("Failed to collect: " + attribute.getObjectName() + "@" + attribute.getConnection().getRawUrl() + " InstanceNotFound consecutive count=" + attribute.getConsecutiveNotFounds());
+				} else {
+					dispatchable.addAll(result.get().getValues());
+					success++;
+				}
 			} catch (ExecutionException ex) {
 				failed++;
 				logger.warning("Failed to collect: " + ex.getCause());


### PR DESCRIPTION
Reproduced the errors with JBoss undeploying beans but leaving them discoverable.

This was especially noticeable with JDBC pools.

Instead of closing the connection or failing all the items, log when this occurs, and keep track of the consecutive failures (for future use?)

If the MBean is available at a later date, the collections will resume seamlessly.
If the TTL on the connection is reached, these MBean collection references will be discarded during the reconnect.
