### PR TITLE
Do not add value list if it contains null after conversion

### DIFF
--- a/src/main/java/com/e_gineering/collectd/AttributePermutation.java
+++ b/src/main/java/com/e_gineering/collectd/AttributePermutation.java
@@ -330,11 +330,14 @@ public class AttributePermutation implements Callable<AttributePermutation>, Com
 				}
 			} else if (!values.contains(null)) {
 				ValueList vl = new ValueList(callVal);
-				vl.setValues(genericListToNumber(values));
-				if (logger.isLoggable(Level.FINEST)) {
-					logger.finest("dispatch " + vl);
+				List<Number> numberList = genericListToNumber(values);
+				if (!numberList.contains(null)) {
+					vl.setValues(genericListToNumber(values));
+					if (logger.isLoggable(Level.FINEST)) {
+						logger.finest("dispatch " + vl);
+					}
+					dispatch.add(vl);
 				}
-				dispatch.add(vl);
 			}
 			interruptedOrFailed = false;
 		} catch (IOException ioe) {


### PR DESCRIPTION
Does this patch make sense for your use cases?

I specify a large number of MBean attributes in the config, some of those attributes don't exist on some MBeans which causes a lot of 'error' level logging from the java plugin. I resolve this by ignoring value lists that contain null.
